### PR TITLE
Implement shared bullet pooling with PoolManager

### DIFF
--- a/Assets/0. Script/Enemies/EnemyA.cs
+++ b/Assets/0. Script/Enemies/EnemyA.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 
 public class EnemyA : Enemy
 {
-    [SerializeField] private GameObject bulletPrefab;
     [SerializeField] private float fireInterval = 1f;
 
     private float fireTimer;
@@ -18,12 +17,11 @@ public class EnemyA : Enemy
         if (fireTimer >= fireInterval)
         {
             fireTimer = 0f;
-            if (bulletPrefab != null)
+            EnemyBullet bullet = PoolManager.Instance.Get<EnemyBullet>(
+                EnemyBullet.PoolKey, transform.position, Quaternion.identity);
+            if (bullet != null)
             {
-                GameObject bullet = Instantiate(bulletPrefab, transform.position, Quaternion.identity);
-                EnemyBullet eb = bullet.GetComponent<EnemyBullet>();
-                if (eb != null)
-                    eb.SetDirection(Vector2.down);
+                bullet.Fire(Vector2.down);
             }
         }
     }

--- a/Assets/0. Script/Enemies/EnemyB.cs
+++ b/Assets/0. Script/Enemies/EnemyB.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 
 public class EnemyB : Enemy
 {
-    [SerializeField] private GameObject bulletPrefab;
     [SerializeField] private int bulletCount = 8;
 
     private void Awake()
@@ -28,16 +27,14 @@ public class EnemyB : Enemy
 
     private void SprinkleBullets()
     {
-        if (bulletPrefab == null) return;
-
         for (int i = 0; i < bulletCount; i++)
         {
             float angle = (360f / bulletCount) * i;
             Vector2 dir = Quaternion.Euler(0f, 0f, angle) * Vector2.up;
-            GameObject bullet = Instantiate(bulletPrefab, transform.position, Quaternion.identity);
-            EnemyBullet eb = bullet.GetComponent<EnemyBullet>();
-            if (eb != null)
-                eb.SetDirection(dir);
+            EnemyBullet bullet = PoolManager.Instance.Get<EnemyBullet>(
+                EnemyBullet.PoolKey, transform.position, Quaternion.identity);
+            if (bullet != null)
+                bullet.Fire(dir);
         }
     }
 }

--- a/Assets/0. Script/EnemyBullet.cs
+++ b/Assets/0. Script/EnemyBullet.cs
@@ -2,12 +2,22 @@ using UnityEngine;
 
 public class EnemyBullet : MonoBehaviour
 {
+    public const string PoolKey = "EnemyBullet";
+
     [SerializeField] private float speed = 5f;
     [SerializeField] private int damage = 1;
+    [SerializeField] private float lifeTime = 5f;
 
     private Vector2 direction = Vector2.down;
+    private float lifeTimer;
 
-    public void SetDirection(Vector2 dir)
+    private void OnEnable()
+    {
+        lifeTimer = 0f;
+        direction = Vector2.down;
+    }
+
+    public void Fire(Vector2 dir)
     {
         direction = dir.normalized;
     }
@@ -15,15 +25,20 @@ public class EnemyBullet : MonoBehaviour
     private void Update()
     {
         transform.Translate(direction * speed * Time.deltaTime);
+        lifeTimer += Time.deltaTime;
+        if (lifeTimer >= lifeTime)
+        {
+            PoolManager.Instance.Return(PoolKey, this);
+        }
     }
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        Player player = collision.GetComponent<Player>();
-        if (player != null)
+        IDamageable target = collision.GetComponent<IDamageable>();
+        if (target != null)
         {
-            player.TakeDamage(damage);
-            gameObject.SetActive(false);
+            target.TakeDamage(damage);
+            PoolManager.Instance.Return(PoolKey, this);
         }
     }
 }

--- a/Assets/0. Script/Player.cs
+++ b/Assets/0. Script/Player.cs
@@ -3,7 +3,6 @@ using UnityEngine;
 public class Player : MonoBehaviour, IDamageable
 {
     [SerializeField] private int health = 10;
-    [SerializeField] private GameObject bulletPrefab;
     [SerializeField] private Transform firePoint;
     [SerializeField] private float attackInterval = 0.2f;
 
@@ -23,10 +22,10 @@ public class Player : MonoBehaviour, IDamageable
 
     private void Attack()
     {
-        if (bulletPrefab == null || firePoint == null)
+        if (firePoint == null)
             return;
 
-        Instantiate(bulletPrefab, firePoint.position, firePoint.rotation);
+        PoolManager.Instance.Get<PlayerBullet>(PlayerBullet.PoolKey, firePoint.position, firePoint.rotation);
     }
 
     public void Heal(int amount)

--- a/Assets/0. Script/PlayerBullet.cs
+++ b/Assets/0. Script/PlayerBullet.cs
@@ -2,12 +2,27 @@ using UnityEngine;
 
 public class PlayerBullet : MonoBehaviour
 {
+    public const string PoolKey = "PlayerBullet";
+
     [SerializeField] private float speed = 10f;
     [SerializeField] private int damage = 1;
+    [SerializeField] private float lifeTime = 3f;
+
+    private float lifeTimer;
+
+    private void OnEnable()
+    {
+        lifeTimer = 0f;
+    }
 
     private void Update()
     {
         transform.Translate(Vector2.up * speed * Time.deltaTime);
+        lifeTimer += Time.deltaTime;
+        if (lifeTimer >= lifeTime)
+        {
+            PoolManager.Instance.Return(PoolKey, this);
+        }
     }
 
     private void OnTriggerEnter2D(Collider2D collision)
@@ -16,7 +31,7 @@ public class PlayerBullet : MonoBehaviour
         if (target != null)
         {
             target.TakeDamage(damage);
-            gameObject.SetActive(false);
+            PoolManager.Instance.Return(PoolKey, this);
         }
     }
 }

--- a/Assets/0. Script/PoolManager.cs
+++ b/Assets/0. Script/PoolManager.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PoolManager : MonoBehaviour
+{
+    public static PoolManager Instance { get; private set; }
+
+    private readonly Dictionary<string, object> pools = new Dictionary<string, object>();
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+    }
+
+    public void Register<T>(string key, T prefab, int size) where T : Component
+    {
+        if (pools.ContainsKey(key))
+        {
+            Debug.LogWarning($"[Pool] Key already registered: {key}");
+            return;
+        }
+
+        ObjectPool<T> pool = new ObjectPool<T>(prefab, size);
+        pools.Add(key, pool);
+    }
+
+    public T Get<T>(string key, Vector3 pos, Quaternion rot) where T : Component
+    {
+        if (pools.TryGetValue(key, out var poolObj))
+        {
+            ObjectPool<T> pool = poolObj as ObjectPool<T>;
+            if (pool != null)
+            {
+                T obj = pool.Get();
+                obj.transform.SetPositionAndRotation(pos, rot);
+                return obj;
+            }
+        }
+
+        Debug.LogWarning($"[Pool] No pool found for key: {key}");
+        return null;
+    }
+
+    public void Return<T>(string key, T obj) where T : Component
+    {
+        if (pools.TryGetValue(key, out var poolObj))
+        {
+            ObjectPool<T> pool = poolObj as ObjectPool<T>;
+            if (pool != null)
+            {
+                pool.Return(obj);
+                return;
+            }
+        }
+
+        Debug.LogWarning($"[Pool] No pool found for key: {key}");
+    }
+}

--- a/Assets/0. Script/PoolManager.cs.meta
+++ b/Assets/0. Script/PoolManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2bbd2b40e966440f99c106fa545117e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/0. Script/PoolSetup.cs
+++ b/Assets/0. Script/PoolSetup.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+public class PoolSetup : MonoBehaviour
+{
+    [SerializeField] private PlayerBullet playerBulletPrefab;
+    [SerializeField] private int playerBulletSize = 10;
+    [SerializeField] private EnemyBullet enemyBulletPrefab;
+    [SerializeField] private int enemyBulletSize = 10;
+
+    private void Awake()
+    {
+        if (playerBulletPrefab != null)
+            PoolManager.Instance.Register(PlayerBullet.PoolKey, playerBulletPrefab, playerBulletSize);
+        if (enemyBulletPrefab != null)
+            PoolManager.Instance.Register(EnemyBullet.PoolKey, enemyBulletPrefab, enemyBulletSize);
+    }
+}

--- a/Assets/0. Script/PoolSetup.cs.meta
+++ b/Assets/0. Script/PoolSetup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76c3a17551834542bc943f0971dd1d09
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add `PoolManager` singleton to register pools and manage retrieval/return
- register bullet prefabs in `PoolSetup`
- use pooling for `PlayerBullet`, `EnemyBullet`, and enemy shooters

## Testing
- `mcs $(find Assets -name '*.cs')` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b48a5c19883218e4e3e7ffe977b31