### PR TITLE
Implement item power-ups and ranking

### DIFF
--- a/Assets/0. Script/GameManager.cs
+++ b/Assets/0. Script/GameManager.cs
@@ -6,6 +6,8 @@ public class GameManager : MonoBehaviour
 
     private int score;
 
+    public int Score => score;
+
     private void Awake()
     {
         if (Instance != null && Instance != this)
@@ -19,5 +21,18 @@ public class GameManager : MonoBehaviour
     public void AddScore(int amount)
     {
         score += amount;
+    }
+
+    public void RegisterScore()
+    {
+        LocalRanking.AddScore(score);
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            RegisterScore();
+        }
     }
 }

--- a/Assets/0. Script/Items/BoomItem.cs
+++ b/Assets/0. Script/Items/BoomItem.cs
@@ -2,10 +2,14 @@ using UnityEngine;
 
 public class BoomItem : Item
 {
-    [SerializeField] private int healAmount = 1;
+    [SerializeField] private int boomAmount = 1;
 
     public override void Apply(Player player)
     {
-        player.Heal(healAmount);
+        PlayerBoom boom = player.GetComponent<PlayerBoom>();
+        if (boom != null)
+        {
+            boom.AddBoom(boomAmount);
+        }
     }
 }

--- a/Assets/0. Script/Items/PowerItem.cs
+++ b/Assets/0. Script/Items/PowerItem.cs
@@ -4,6 +4,6 @@ public class PowerItem : Item
 {
     public override void Apply(Player player)
     {
-        // TODO: Implement attack buff logic
+        player.PowerUp();
     }
 }

--- a/Assets/0. Script/LocalRanking.cs
+++ b/Assets/0. Script/LocalRanking.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+public static class LocalRanking
+{
+    private const string KeyFormat = "LocalRank_{0}";
+    private const int MaxRank = 5;
+
+    public static void AddScore(int score)
+    {
+        int[] ranks = GetScores();
+        for (int i = 0; i < MaxRank; i++)
+        {
+            if (score > ranks[i])
+            {
+                for (int j = MaxRank - 1; j > i; j--)
+                {
+                    ranks[j] = ranks[j - 1];
+                }
+                ranks[i] = score;
+                break;
+            }
+        }
+
+        for (int i = 0; i < MaxRank; i++)
+        {
+            PlayerPrefs.SetInt(string.Format(KeyFormat, i), ranks[i]);
+        }
+        PlayerPrefs.Save();
+    }
+
+    public static int[] GetScores()
+    {
+        int[] ranks = new int[MaxRank];
+        for (int i = 0; i < MaxRank; i++)
+        {
+            ranks[i] = PlayerPrefs.GetInt(string.Format(KeyFormat, i), 0);
+        }
+        return ranks;
+    }
+}

--- a/Assets/0. Script/LocalRanking.cs.meta
+++ b/Assets/0. Script/LocalRanking.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1fff0a9c15340f6b8d9f6ecdeb9a162
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/0. Script/Player.cs
+++ b/Assets/0. Script/Player.cs
@@ -6,9 +6,15 @@ public class Player : MonoBehaviour, IDamageable
     [SerializeField] private Transform firePoint;
     [SerializeField] private float attackInterval = 0.2f;
 
+    [SerializeField] private float spreadAngle = 10f;
+
+    private int powerLevel = 1;
+    private int bulletCount = 1;
     private float attackTimer;
 
     public int Health => health;
+    public int PowerLevel => powerLevel;
+    public int BulletCount => bulletCount;
 
     private void Update()
     {
@@ -25,7 +31,12 @@ public class Player : MonoBehaviour, IDamageable
         if (firePoint == null)
             return;
 
-        PoolManager.Instance.Get<PlayerBullet>(PlayerBullet.PoolKey, firePoint.position, firePoint.rotation);
+        float startAngle = -(bulletCount - 1) * spreadAngle * 0.5f;
+        for (int i = 0; i < bulletCount; i++)
+        {
+            Quaternion rot = firePoint.rotation * Quaternion.Euler(0f, 0f, startAngle + spreadAngle * i);
+            PoolManager.Instance.Get<PlayerBullet>(PlayerBullet.PoolKey, firePoint.position, rot);
+        }
     }
 
     public void Heal(int amount)
@@ -43,5 +54,19 @@ public class Player : MonoBehaviour, IDamageable
     private void Die()
     {
         gameObject.SetActive(false);
+        GameManager.Instance?.RegisterScore();
+    }
+
+    public void PowerUp()
+    {
+        powerLevel++;
+        if (powerLevel % 2 == 0)
+        {
+            bulletCount++;
+        }
+        else
+        {
+            attackInterval = Mathf.Max(0.1f, attackInterval - 0.2f);
+        }
     }
 }

--- a/Assets/0. Script/PlayerBoom.cs
+++ b/Assets/0. Script/PlayerBoom.cs
@@ -4,9 +4,22 @@ public class PlayerBoom : MonoBehaviour
 {
     [SerializeField] private float radius = 3f;
     [SerializeField] private int damage = 10;
+    [SerializeField] private int boomCount = 0;
+
+    public int BoomCount => boomCount;
+
+    public void AddBoom(int amount)
+    {
+        boomCount += amount;
+    }
 
     public void Boom()
     {
+        if (boomCount <= 0)
+            return;
+
+        boomCount--;
+
         Collider2D[] hits = Physics2D.OverlapCircleAll(transform.position, radius);
         foreach (var hit in hits)
         {


### PR DESCRIPTION
## Summary
- Make BoomItem grant extra bomb charges
- PowerItem now upgrades attack rate and bullet count
- Track scores and persist a local ranking board

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7024d00d08321911f25aafc3a899d