### PR TITLE
Add controllable player boom projectile

### DIFF
--- a/Assets/0. Script/PlayerBoom.cs
+++ b/Assets/0. Script/PlayerBoom.cs
@@ -2,8 +2,6 @@ using UnityEngine;
 
 public class PlayerBoom : MonoBehaviour
 {
-    [SerializeField] private float radius = 3f;
-    [SerializeField] private int damage = 10;
     [SerializeField] private int boomCount = 0;
 
     public int BoomCount => boomCount;
@@ -20,22 +18,7 @@ public class PlayerBoom : MonoBehaviour
 
         boomCount--;
 
-        Collider2D[] hits = Physics2D.OverlapCircleAll(transform.position, radius);
-        foreach (var hit in hits)
-        {
-            Enemy enemy = hit.GetComponent<Enemy>();
-            if (enemy != null)
-            {
-                enemy.TakeDamage(damage);
-            }
-        }
+        Vector3 spawnPos = new Vector3(transform.position.x, -10f, 0f);
+        PoolManager.Instance.Get<PlayerBoomProjectile>(PlayerBoomProjectile.PoolKey, spawnPos, Quaternion.identity);
     }
-
-#if UNITY_EDITOR
-    private void OnDrawGizmosSelected()
-    {
-        Gizmos.color = Color.red;
-        Gizmos.DrawWireSphere(transform.position, radius);
-    }
-#endif
 }

--- a/Assets/0. Script/PlayerBoomProjectile.cs
+++ b/Assets/0. Script/PlayerBoomProjectile.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+public class PlayerBoomProjectile : MonoBehaviour
+{
+    public const string PoolKey = "PlayerBoom";
+
+    [SerializeField] private float speed = 5f;
+    [SerializeField] private int damage = 1;
+
+    private void Update()
+    {
+        transform.Translate(Vector2.up * speed * Time.deltaTime);
+        if (transform.position.y >= 10f)
+        {
+            PoolManager.Instance.Return(PoolKey, this);
+        }
+    }
+
+    private void OnTriggerStay2D(Collider2D collision)
+    {
+        IDamageable target = collision.GetComponent<IDamageable>();
+        if (target != null && collision.tag != "Player")
+        {
+            target.TakeDamage(damage);
+        }
+    }
+}

--- a/Assets/0. Script/PlayerController.cs
+++ b/Assets/0. Script/PlayerController.cs
@@ -17,7 +17,7 @@ public class PlayerController : MonoBehaviour
     private void Update()
     {
         HandleMovement();
-        if (Input.GetKeyDown(KeyCode.Space))
+        if (Input.GetKeyDown(KeyCode.X))
         {
             boom?.Boom();
         }

--- a/Assets/0. Script/PoolSetup.cs
+++ b/Assets/0. Script/PoolSetup.cs
@@ -6,6 +6,8 @@ public class PoolSetup : MonoBehaviour
     [SerializeField] private int playerBulletSize = 10;
     [SerializeField] private EnemyBullet enemyBulletPrefab;
     [SerializeField] private int enemyBulletSize = 10;
+    [SerializeField] private PlayerBoomProjectile playerBoomPrefab;
+    [SerializeField] private int playerBoomSize = 1;
 
     private void Awake()
     {
@@ -13,5 +15,7 @@ public class PoolSetup : MonoBehaviour
             PoolManager.Instance.Register(PlayerBullet.PoolKey, playerBulletPrefab, playerBulletSize);
         if (enemyBulletPrefab != null)
             PoolManager.Instance.Register(EnemyBullet.PoolKey, enemyBulletPrefab, enemyBulletSize);
+        if (playerBoomPrefab != null)
+            PoolManager.Instance.Register(PlayerBoomProjectile.PoolKey, playerBoomPrefab, playerBoomSize);
     }
 }


### PR DESCRIPTION
## Summary
- Fire a PlayerBoom with X that spawns at the bottom and rises upward
- PlayerBoom projectile deals continuous damage and disappears at map top
- Register PlayerBoom projectile in object pool

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a707c4e8d08321a7b61a60fc66e370