### PR TITLE
Show damage text when objects take damage

### DIFF
--- a/Assets/0. Script/DamageText.cs
+++ b/Assets/0. Script/DamageText.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+using TMPro;
+
+public class DamageText : MonoBehaviour
+{
+    private TMP_Text text;
+    private float duration = 1f;
+    private float timer;
+    private float moveSpeed = 1f;
+
+    public static void Create(int amount, Vector3 position)
+    {
+        GameObject obj = new GameObject("DamageText");
+        obj.transform.position = position;
+        DamageText dmgText = obj.AddComponent<DamageText>();
+        dmgText.Setup(amount);
+    }
+
+    private void Awake()
+    {
+        text = gameObject.AddComponent<TextMeshPro>();
+        text.fontSize = 36;
+        text.color = Color.white;
+        text.alignment = TextAlignmentOptions.Center;
+    }
+
+    private void Setup(int amount)
+    {
+        text.text = amount.ToString();
+    }
+
+    private void Update()
+    {
+        timer += Time.deltaTime;
+        transform.position += Vector3.up * moveSpeed * Time.deltaTime;
+        float alpha = 1f - timer / duration;
+        Color c = text.color;
+        c.a = alpha;
+        text.color = c;
+        if (timer >= duration)
+        {
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/0. Script/Enemies/Enemy.cs
+++ b/Assets/0. Script/Enemies/Enemy.cs
@@ -22,6 +22,7 @@ public abstract class Enemy : MonoBehaviour, IDamageable, IAttack, IMove
     public virtual void TakeDamage(int amount)
     {
         health -= amount;
+        DamageText.Create(amount, transform.position);
         if (health <= 0)
             Die();
     }

--- a/Assets/0. Script/Player.cs
+++ b/Assets/0. Script/Player.cs
@@ -47,6 +47,7 @@ public class Player : MonoBehaviour, IDamageable
     public void TakeDamage(int amount)
     {
         health -= amount;
+        DamageText.Create(amount, transform.position);
         if (health <= 0)
             Die();
     }


### PR DESCRIPTION
## Summary
- spawn floating white damage text above any IDamageable when it takes damage
- introduce `DamageText` component to animate, fade out, and clean up text objects

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a710a439c48321ae5c15cf8929519f