### PR TITLE
Implement JSON-driven stage progression system

### DIFF
--- a/Assets/0. Script/Enemies/Enemy.cs
+++ b/Assets/0. Script/Enemies/Enemy.cs
@@ -30,5 +30,6 @@ public abstract class Enemy : MonoBehaviour, IDamageable, IAttack, IMove
     protected virtual void Die()
     {
         gameObject.SetActive(false);
+        StageManager.Instance?.EnemyDefeated();
     }
 }

--- a/Assets/0. Script/Managers/SpawnManager.cs
+++ b/Assets/0. Script/Managers/SpawnManager.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 public class SpawnManager : MonoBehaviour
@@ -5,12 +7,45 @@ public class SpawnManager : MonoBehaviour
     [SerializeField] private Enemy[] enemies;
     [SerializeField] private Transform[] spawnPoints;
 
-    public void Spawn(int index)
+    private Dictionary<string, Enemy> enemyDict;
+
+    private void Awake()
     {
-        if (enemies.Length == 0 || spawnPoints.Length == 0)
+        enemyDict = new Dictionary<string, Enemy>();
+        foreach (Enemy enemy in enemies)
+        {
+            if (enemy != null)
+                enemyDict[enemy.GetType().Name] = enemy;
+        }
+    }
+
+    public void Spawn(string type)
+    {
+        if (enemyDict.Count == 0 || spawnPoints.Length == 0)
+            return;
+        if (!enemyDict.TryGetValue(type, out Enemy prefab))
             return;
 
         int spawnIndex = Random.Range(0, spawnPoints.Length);
-        Instantiate(enemies[index], spawnPoints[spawnIndex].position, Quaternion.identity);
+        Instantiate(prefab, spawnPoints[spawnIndex].position, Quaternion.identity);
+    }
+
+    public IEnumerator SpawnStage(StageInfo stage)
+    {
+        List<string> queue = new List<string>();
+        foreach (EnemySpawnInfo info in stage.enemies)
+        {
+            for (int i = 0; i < info.count; i++)
+                queue.Add(info.type);
+        }
+
+        while (queue.Count > 0)
+        {
+            int idx = Random.Range(0, queue.Count);
+            string type = queue[idx];
+            queue.RemoveAt(idx);
+            Spawn(type);
+            yield return new WaitForSeconds(Random.Range(1f, 2f));
+        }
     }
 }

--- a/Assets/0. Script/Managers/StageData.cs
+++ b/Assets/0. Script/Managers/StageData.cs
@@ -1,0 +1,20 @@
+using System;
+
+[Serializable]
+public class StageData
+{
+    public StageInfo[] stages;
+}
+
+[Serializable]
+public class StageInfo
+{
+    public EnemySpawnInfo[] enemies;
+}
+
+[Serializable]
+public class EnemySpawnInfo
+{
+    public string type;
+    public int count;
+}

--- a/Assets/0. Script/Managers/StageData.cs.meta
+++ b/Assets/0. Script/Managers/StageData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f86d91a97531431aafd19c1aa9033431
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/0. Script/Managers/StageManager.cs
+++ b/Assets/0. Script/Managers/StageManager.cs
@@ -1,0 +1,53 @@
+using System.Collections;
+using System.Linq;
+using UnityEngine;
+
+public class StageManager : MonoBehaviour
+{
+    public static StageManager Instance { get; private set; }
+
+    [SerializeField] private SpawnManager spawnManager;
+    private StageData stageData;
+    private int currentStage = -1;
+    private int remainingEnemies;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+
+        TextAsset json = Resources.Load<TextAsset>("Stage");
+        if (json != null)
+            stageData = JsonUtility.FromJson<StageData>(json.text);
+    }
+
+    private void Start()
+    {
+        NextStage();
+    }
+
+    public void EnemyDefeated()
+    {
+        remainingEnemies--;
+        if (remainingEnemies <= 0)
+            NextStage();
+    }
+
+    private void NextStage()
+    {
+        currentStage++;
+        if (stageData == null || currentStage >= stageData.stages.Length)
+        {
+            Debug.Log("All stages cleared!");
+            return;
+        }
+
+        StageInfo stage = stageData.stages[currentStage];
+        remainingEnemies = stage.enemies.Sum(e => e.count);
+        StartCoroutine(spawnManager.SpawnStage(stage));
+    }
+}

--- a/Assets/0. Script/Managers/StageManager.cs.meta
+++ b/Assets/0. Script/Managers/StageManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da5d0c6ee921421f978f2115c0db53ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0681e5dd28f84ead92061be3085c7b6c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Stage.json
+++ b/Assets/Resources/Stage.json
@@ -1,0 +1,34 @@
+{
+  "stages": [
+    {
+      "enemies": [
+        { "type": "EnemyA", "count": 5 }
+      ]
+    },
+    {
+      "enemies": [
+        { "type": "EnemyA", "count": 4 },
+        { "type": "EnemyB", "count": 2 }
+      ]
+    },
+    {
+      "enemies": [
+        { "type": "EnemyA", "count": 3 },
+        { "type": "EnemyB", "count": 3 },
+        { "type": "EnemyC", "count": 2 }
+      ]
+    },
+    {
+      "enemies": [
+        { "type": "EnemyA", "count": 3 },
+        { "type": "EnemyB", "count": 3 },
+        { "type": "EnemyC", "count": 3 }
+      ]
+    },
+    {
+      "enemies": [
+        { "type": "EnemyBoss", "count": 1 }
+      ]
+    }
+  ]
+}

--- a/Assets/Resources/Stage.json.meta
+++ b/Assets/Resources/Stage.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5d3deb80b4e14c44b5e49846bb8d49a5
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Add `StageManager` and supporting data classes to drive stages from a JSON file
- Extend `SpawnManager` to spawn enemies based on stage definitions with randomized intervals and spawn points
- Track enemy defeats and stage transitions, culminating in a boss-only final stage

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8481438f88321ae5d24c99013c7d0