### PR TITLE
Add stage notice UI

### DIFF
--- a/Assets/0. Script/Managers/StageManager.cs
+++ b/Assets/0. Script/Managers/StageManager.cs
@@ -47,6 +47,7 @@ public class StageManager : MonoBehaviour
         }
 
         StageInfo stage = stageData.stages[currentStage];
+        StageNoticeUI.Show(currentStage + 1);
         remainingEnemies = stage.enemies.Sum(e => e.count);
         StartCoroutine(spawnManager.SpawnStage(stage));
     }

--- a/Assets/0. Script/StageNoticeUI.cs
+++ b/Assets/0. Script/StageNoticeUI.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+using TMPro;
+
+public class StageNoticeUI : MonoBehaviour
+{
+    private TMP_Text text;
+    private CanvasGroup canvasGroup;
+    private float duration = 2f;
+    private float timer;
+
+    public static void Show(int stage)
+    {
+        GameObject obj = new GameObject("StageNoticeUI");
+        Canvas canvas = obj.AddComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        StageNoticeUI notice = obj.AddComponent<StageNoticeUI>();
+        notice.Setup(stage);
+    }
+
+    private void Setup(int stage)
+    {
+        canvasGroup = gameObject.AddComponent<CanvasGroup>();
+
+        GameObject textObj = new GameObject("Text");
+        textObj.transform.SetParent(transform);
+        text = textObj.AddComponent<TextMeshProUGUI>();
+        text.text = $"Stage {stage}";
+        text.fontSize = 48f;
+        text.alignment = TextAlignmentOptions.Top;
+
+        RectTransform rt = text.rectTransform;
+        rt.anchorMin = new Vector2(0.5f, 1f);
+        rt.anchorMax = new Vector2(0.5f, 1f);
+        rt.pivot = new Vector2(0.5f, 1f);
+        rt.anchoredPosition = new Vector2(0f, -50f);
+    }
+
+    private void Update()
+    {
+        timer += Time.deltaTime;
+        float alpha = 1f - timer / duration;
+        canvasGroup.alpha = alpha;
+        if (timer >= duration)
+            Destroy(gameObject);
+    }
+}


### PR DESCRIPTION
## Summary
- show "Stage n" at top of screen when new stage begins
- fade notice over two seconds

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a86e04b8408321b6c59cdce95be982