### PR TITLE
Aim enemies towards player

### DIFF
--- a/Assets/0. Script/Enemies/EnemyA.cs
+++ b/Assets/0. Script/Enemies/EnemyA.cs
@@ -3,12 +3,36 @@ using UnityEngine;
 public class EnemyA : Enemy
 {
     [SerializeField] private float fireInterval = 1f;
+    [SerializeField] private float rotateSpeed = 180f;
 
     private float fireTimer;
+    private Transform player;
 
     private void Awake()
     {
         speed = 2f;
+    }
+
+    private void Start()
+    {
+        player = FindObjectOfType<Player>()?.transform;
+    }
+
+    public override void Move()
+    {
+        base.Move();
+        RotateTowardsPlayer();
+    }
+
+    private void RotateTowardsPlayer()
+    {
+        if (player == null)
+            return;
+
+        Vector2 dir = player.position - transform.position;
+        float angle = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg - 90f;
+        Quaternion target = Quaternion.Euler(0f, 0f, angle);
+        transform.rotation = Quaternion.RotateTowards(transform.rotation, target, rotateSpeed * Time.deltaTime);
     }
 
     public override void Attack()
@@ -21,7 +45,8 @@ public class EnemyA : Enemy
                 EnemyBullet.PoolKey, transform.position, Quaternion.identity);
             if (bullet != null)
             {
-                bullet.Fire(Vector2.down);
+                Vector2 dir = player != null ? (player.position - transform.position).normalized : Vector2.down;
+                bullet.Fire(dir);
             }
         }
     }

--- a/Assets/0. Script/Enemies/EnemyC.cs
+++ b/Assets/0. Script/Enemies/EnemyC.cs
@@ -5,12 +5,36 @@ public class EnemyC : Enemy
     [SerializeField] private float beamInterval = 2f;
     [SerializeField] private float beamRange = 10f;
     [SerializeField] private int beamDamage = 1;
+    [SerializeField] private float rotateSpeed = 180f;
 
     private float attackTimer;
+    private Transform player;
 
     private void Awake()
     {
         speed = 1.5f;
+    }
+
+    private void Start()
+    {
+        player = FindObjectOfType<Player>()?.transform;
+    }
+
+    public override void Move()
+    {
+        base.Move();
+        RotateTowardsPlayer();
+    }
+
+    private void RotateTowardsPlayer()
+    {
+        if (player == null)
+            return;
+
+        Vector2 dir = player.position - transform.position;
+        float angle = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg - 90f;
+        Quaternion target = Quaternion.Euler(0f, 0f, angle);
+        transform.rotation = Quaternion.RotateTowards(transform.rotation, target, rotateSpeed * Time.deltaTime);
     }
 
     public override void Attack()
@@ -19,12 +43,16 @@ public class EnemyC : Enemy
         if (attackTimer >= beamInterval)
         {
             attackTimer = 0f;
-            RaycastHit2D hit = Physics2D.Raycast(transform.position, Vector2.down, beamRange);
+            if (player == null)
+                return;
+
+            Vector2 dir = (player.position - transform.position).normalized;
+            RaycastHit2D hit = Physics2D.Raycast(transform.position, dir, beamRange);
             if (hit.collider != null)
             {
-                Player player = hit.collider.GetComponent<Player>();
-                if (player != null)
-                    player.TakeDamage(beamDamage);
+                Player playerHit = hit.collider.GetComponent<Player>();
+                if (playerHit != null)
+                    playerHit.TakeDamage(beamDamage);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Make EnemyA and EnemyC continuously rotate toward the player with a configurable rotation speed
- Fire EnemyA bullets and EnemyC beams toward the player's current position

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a88191db84832188b188ba972b601d