### PR TITLE
Load enemy stats from ScriptableObjects

### DIFF
--- a/Assets/0. Script/Enemies/Enemy.cs
+++ b/Assets/0. Script/Enemies/Enemy.cs
@@ -2,9 +2,24 @@ using UnityEngine;
 
 public abstract class Enemy : MonoBehaviour, IDamageable, IAttack, IMove
 {
-    [SerializeField] protected int health = 1;
-    [SerializeField] protected float speed = 1f;
+    [SerializeField] private EnemyStats stats;
+
+    protected int health;
+    protected float speed;
     public int Health => health;
+
+    protected virtual void Awake()
+    {
+        if (stats != null)
+            ApplyStats(stats);
+    }
+
+    public void ApplyStats(EnemyStats newStats)
+    {
+        stats = newStats;
+        health = stats.health;
+        speed = stats.speed;
+    }
 
     private void Update()
     {

--- a/Assets/0. Script/Enemies/EnemyA.cs
+++ b/Assets/0. Script/Enemies/EnemyA.cs
@@ -8,11 +8,6 @@ public class EnemyA : Enemy
     private float fireTimer;
     private Transform player;
 
-    private void Awake()
-    {
-        speed = 2f;
-    }
-
     private void Start()
     {
         player = FindObjectOfType<Player>()?.transform;

--- a/Assets/0. Script/Enemies/EnemyB.cs
+++ b/Assets/0. Script/Enemies/EnemyB.cs
@@ -4,11 +4,6 @@ public class EnemyB : Enemy
 {
     [SerializeField] private int bulletCount = 8;
 
-    private void Awake()
-    {
-        speed = 3f;
-    }
-
     public override void Attack()
     {
         // EnemyB attacks by colliding with the player.

--- a/Assets/0. Script/Enemies/EnemyC.cs
+++ b/Assets/0. Script/Enemies/EnemyC.cs
@@ -10,11 +10,6 @@ public class EnemyC : Enemy
     private float attackTimer;
     private Transform player;
 
-    private void Awake()
-    {
-        speed = 1.5f;
-    }
-
     private void Start()
     {
         player = FindObjectOfType<Player>()?.transform;

--- a/Assets/0. Script/Enemies/EnemyStats.cs
+++ b/Assets/0. Script/Enemies/EnemyStats.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "EnemyStats", menuName = "ScriptableObjects/EnemyStats", order = 1)]
+public class EnemyStats : ScriptableObject
+{
+    public int health = 1;
+    public float speed = 1f;
+}

--- a/Assets/0. Script/Enemies/EnemyStats.cs.meta
+++ b/Assets/0. Script/Enemies/EnemyStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d0a2720b559444692e7a73d225d4eda
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/0. Script/Managers/SpawnManager.cs
+++ b/Assets/0. Script/Managers/SpawnManager.cs
@@ -27,7 +27,10 @@ public class SpawnManager : MonoBehaviour
             return;
 
         int spawnIndex = Random.Range(0, spawnPoints.Length);
-        Instantiate(prefab, spawnPoints[spawnIndex].position, Quaternion.identity);
+        Enemy instance = Instantiate(prefab, spawnPoints[spawnIndex].position, Quaternion.identity);
+        EnemyStats stats = Resources.Load<EnemyStats>($"EnemyStats/{type}");
+        if (stats != null)
+            instance.ApplyStats(stats);
     }
 
     public IEnumerator SpawnStage(StageInfo stage)


### PR DESCRIPTION
## Summary
- Added `EnemyStats` ScriptableObject to house health and speed values.
- Enemies now apply stats from ScriptableObjects and SpawnManager loads them on spawn.

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a89052bac48321a44f121d1b8c2cc8